### PR TITLE
Publish odometry and current steering angle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ syntax: glob
 *.stl
 *.idea
 *.pyc
+**/.vscode

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ To control the vehicle, publish the following topics:
 - **throttle_cmd** - `std_msgs/Float64` topic containing the desired throttle percentage (range 0 to 1)
 - **gear_cmd** - `std_msgs/UInt8` topic containing the desired gear (`DRIVE` = 0, `REVERSE` = 1)
 
-Ground truth speed and yaw rate feedback are provided on the **twist** topic, which is of type `geometry_msgs/TwistStamped`
+Ground truth speed and yaw rate feedback are provided on the **twist** topic, which is of type `geometry_msgs/TwistStamped`.
 
 Current gear state is provided on the **gear_state** topic, which is of type `std_msgs/UInt8`. The gear state starts in `DRIVE` by default.
+
+The current steering wheel angle is provided on the **steering_state** topic, which is of type `std_msgs/Float64`.
+
+Position, orientation and twist is provided on the **odom** topic, which is of type `nav_msgs/Odometry`.
 
 Some useful kinematics parameters:
 

--- a/audibot_description/urdf/audibot.urdf.xacro
+++ b/audibot_description/urdf/audibot.urdf.xacro
@@ -146,19 +146,6 @@
     <child link="base_link"/>
   </joint>
 
-  <link name="front_axle">
-    <inertial>
-      <mass value="0.1"/>
-      <inertia ixx="0.0001" ixy="0.0001" ixz="0.0001" iyy="0.0001" iyz="0.0001" izz="0.0001" />
-    </inertial>
-  </link>
-
-  <joint name="front_axle_joint" type="fixed">
-    <origin xyz="${2*half_wheelbase} 0 0" rpy="0 0 0"/>
-    <parent link="base_footprint"/>
-    <child link="front_axle"/>
-  </joint>
-
   <xacro:rear_wheel name="rl" x="${-half_wheelbase}" y="${half_rear_track_width}" z="0" flip="1" />
   <xacro:rear_wheel name="rr" x="${-half_wheelbase}" y="${-half_rear_track_width}" z="0" flip="0" />
   <xacro:front_wheel name="fl" x="${half_wheelbase}" y="${half_front_track_width}" z="0" flip="1" />
@@ -189,10 +176,5 @@
   <gazebo reference="wheel_rr" >
     <mu1>${wheel_friction}</mu1>
     <mu2>${wheel_friction}</mu2>
-  </gazebo>
-
-  <!-- prevent fixed joint reduction -->
-  <gazebo reference="front_axle_joint" >
-    <preserveFixedJoint>true</preserveFixedJoint>
   </gazebo>
 </robot>

--- a/audibot_description/urdf/audibot.urdf.xacro
+++ b/audibot_description/urdf/audibot.urdf.xacro
@@ -146,6 +146,19 @@
     <child link="base_link"/>
   </joint>
 
+  <link name="front_axle">
+    <inertial>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0.0001" ixz="0.0001" iyy="0.0001" iyz="0.0001" izz="0.0001" />
+    </inertial>
+  </link>
+
+  <joint name="front_axle_joint" type="fixed">
+    <origin xyz="${2*half_wheelbase} 0 0" rpy="0 0 0"/>
+    <parent link="base_footprint"/>
+    <child link="front_axle"/>
+  </joint>
+
   <xacro:rear_wheel name="rl" x="${-half_wheelbase}" y="${half_rear_track_width}" z="0" flip="1" />
   <xacro:rear_wheel name="rr" x="${-half_wheelbase}" y="${-half_rear_track_width}" z="0" flip="0" />
   <xacro:front_wheel name="fl" x="${half_wheelbase}" y="${half_front_track_width}" z="0" flip="1" />
@@ -178,4 +191,8 @@
     <mu2>${wheel_friction}</mu2>
   </gazebo>
 
+  <!-- prevent fixed joint reduction -->
+  <gazebo reference="front_axle_joint" >
+    <preserveFixedJoint>true</preserveFixedJoint>
+  </gazebo>
 </robot>

--- a/audibot_gazebo/include/audibot_gazebo/AudibotInterfacePlugin.h
+++ b/audibot_gazebo/include/audibot_gazebo/AudibotInterfacePlugin.h
@@ -5,6 +5,7 @@
 #include <std_msgs/Float64.h>
 #include <std_msgs/UInt8.h>
 #include <geometry_msgs/TwistStamped.h>
+#include <nav_msgs/Odometry.h>
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/physics/physics.hh>
@@ -58,7 +59,9 @@ private:
 
   ros::NodeHandle* n_;
   ros::Publisher pub_twist_;
+  ros::Publisher pub_odom_;
   ros::Publisher pub_gear_state_;
+  ros::Publisher pub_steering_;
   ros::Subscriber sub_steering_cmd_;
   ros::Subscriber sub_throttle_cmd_;
   ros::Subscriber sub_brake_cmd_;
@@ -72,8 +75,10 @@ private:
   bool rollover_;
 #if GAZEBO_MAJOR_VERSION >= 9
   ignition::math::Pose3d world_pose_;
+  ignition::math::Pose3d front_pose_;
 #else
   gazebo::math::Pose world_pose_;
+  ignition::math::Pose3d front_pose_;
 #endif
   event::ConnectionPtr update_connection_;
   physics::JointPtr steer_fl_joint_;
@@ -83,6 +88,7 @@ private:
   physics::JointPtr wheel_fl_joint_;
   physics::JointPtr wheel_fr_joint_;
   physics::LinkPtr footprint_link_;
+  physics::LinkPtr front_axle_link_;
   common::Time last_update_time_;
   std::string frame_id_;
 

--- a/audibot_gazebo/include/audibot_gazebo/AudibotInterfacePlugin.h
+++ b/audibot_gazebo/include/audibot_gazebo/AudibotInterfacePlugin.h
@@ -75,10 +75,8 @@ private:
   bool rollover_;
 #if GAZEBO_MAJOR_VERSION >= 9
   ignition::math::Pose3d world_pose_;
-  ignition::math::Pose3d front_pose_;
 #else
   gazebo::math::Pose world_pose_;
-  ignition::math::Pose3d front_pose_;
 #endif
   event::ConnectionPtr update_connection_;
   physics::JointPtr steer_fl_joint_;
@@ -88,7 +86,6 @@ private:
   physics::JointPtr wheel_fl_joint_;
   physics::JointPtr wheel_fr_joint_;
   physics::LinkPtr footprint_link_;
-  physics::LinkPtr front_axle_link_;
   common::Time last_update_time_;
   std::string frame_id_;
 

--- a/audibot_gazebo/src/AudibotInterfacePlugin.cpp
+++ b/audibot_gazebo/src/AudibotInterfacePlugin.cpp
@@ -20,10 +20,6 @@ void AudibotInterfacePlugin::Load(physics::ModelPtr model, sdf::ElementPtr sdf) 
   wheel_fl_joint_ = model->GetJoint("wheel_fl_joint");
   wheel_fr_joint_ = model->GetJoint("wheel_fr_joint");
   footprint_link_ = model->GetLink("base_footprint");
-  front_axle_link_ = model->GetLink("front_axle");
-  if (front_axle_link_ == nullptr){
-    ROS_ERROR("front_axle_link_ == nullptr");
-  }
   // Load SDF parameters
   if (sdf->HasElement("pubTf")) {
     sdf->GetElement("pubTf")->GetValue()->Get(pub_tf_);
@@ -64,7 +60,7 @@ void AudibotInterfacePlugin::Load(physics::ModelPtr model, sdf::ElementPtr sdf) 
   pub_twist_ = n_->advertise<geometry_msgs::TwistStamped> ("twist", 1);
   pub_gear_state_ = n_->advertise<std_msgs::UInt8> ("gear_state", 1);
   pub_odom_ = n_->advertise<nav_msgs::Odometry>("odom", 1);
-  pub_steering_ = n_->advertise<std_msgs::Float64>("current_steering_angle", 1);
+  pub_steering_ = n_->advertise<std_msgs::Float64>("steering_state", 1);
   feedback_timer_ = n_->createTimer(ros::Duration(0.02), &AudibotInterfacePlugin::feedbackTimerCallback, this);
 
   if (pub_tf_) {
@@ -93,13 +89,11 @@ void AudibotInterfacePlugin::OnUpdate(const common::UpdateInfo& info) {
 void AudibotInterfacePlugin::twistStateUpdate() {
 #if GAZEBO_MAJOR_VERSION >= 9
   world_pose_ = footprint_link_->WorldPose();
-  front_pose_ = front_axle_link_->WorldPose();
   twist_.linear.x = footprint_link_->RelativeLinearVel().X();
   twist_.angular.z = footprint_link_->RelativeAngularVel().Z();
   rollover_ = (fabs(world_pose_.Rot().X()) > 0.2 || fabs(world_pose_.Rot().Y()) > 0.2);
 #else
   world_pose_ = footprint_link_->GetWorldPose();
-  front_pose_ = front_axle_link_->GetWorldPose();
   twist_.linear.x = footprint_link_->GetRelativeLinearVel().x;
   twist_.angular.z = footprint_link_->GetRelativeAngularVel().z;
   rollover_ = (fabs(world_pose_.rot.x) > 0.2 || fabs(world_pose_.rot.y) > 0.2);
@@ -258,7 +252,6 @@ void AudibotInterfacePlugin::feedbackTimerCallback(const ros::TimerEvent& event)
   gear_state_msg.data = gear_cmd_;
   pub_gear_state_.publish(gear_state_msg);
 
-  // added odom publisher.
   nav_msgs::Odometry odom_msg;
   odom_msg.header.frame_id = frame_id_;
   odom_msg.header.stamp = event.current_real;
@@ -273,7 +266,7 @@ void AudibotInterfacePlugin::feedbackTimerCallback(const ros::TimerEvent& event)
   pub_odom_.publish(odom_msg);
 
   std_msgs::Float64 steering;
-  steering.data = current_steering_angle_;
+  steering.data = AUDIBOT_STEERING_RATIO * current_steering_angle_;
   pub_steering_.publish(steering);
 }
 


### PR DESCRIPTION
Hi!
I'm using your repo to simulate an [autonomous car](https://www.fuelfighter.no/) . My [control system](https://github.com/TorBorve/mpc_local_planner) needs to know the current steering angle of the car to work optimally. Therefore I added a publisher that publishes the current steering angle on the wheels. Also I added a odom publisher since often SLAM algorithms require a odom topic. Lastly I added a front axle link. This was originally because it can be nice to look at the position of the front axle instead of rear axle. However, iẗ́'s not being used at the moment so it could also be removed.

Feel free to come with feedback!